### PR TITLE
Fix missing cursor-color for st

### DIFF
--- a/st/srcery_st.c
+++ b/st/srcery_st.c
@@ -24,6 +24,7 @@ static const char *colorname[] = {
   /* special colors */
   [256] = "#1c1b19", /* background */
   [257] = "#fce8c3", /* foreground */
+  [258] = "#fce8c3", /* cursor */
 };
 
 /*


### PR DESCRIPTION
The missing cursor-color caused my build of `st` to not function
properly.