### PR TITLE
Add Name param to xfce4, rename Config to Scheme

### DIFF
--- a/xfce4/srcery_xfce4.theme
+++ b/xfce4/srcery_xfce4.theme
@@ -1,4 +1,5 @@
-[Configuration]
+[Scheme]
+Name=srcery
 ColorCursor=#fcfce8e8c3c3
 ColorForeground=#fcfce8e8c3c3
 ColorBackground=#1c1c1b1b1919


### PR DESCRIPTION
Made this change so xrcery_xfce4 can be added as a _theme_, in either:
- `/usr/share/xfce4/terminal/colorschemes/`
- `$HOME/.config/xfce4/terminal/colorschemes/`
- `$HOME/.local/share/xfce4/terminal/colorschemes/`