### PR TITLE
chore: config dependabot inside repo

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "semver:minor"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"


### PR DESCRIPTION
Hi,

Recently learned about this, and I've already added to the site source repo.  This could lessen the burden on manually merging new PRs.

Any thoughts on what ranges/versions it's acceptable to automerge?