### PR TITLE
ci: use GitLab Actions for auto merge

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,0 +1,39 @@
+name: Automate Dependency Updates
+
+on:
+  pull_request:
+    paths:
+      - package.json
+    types:
+      - edited
+      - labeled
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+      - unlabeled
+      - unlocked
+  status: {}
+
+jobs:
+  checks:
+    name: Check 4 Changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: npm ci
+      - run: make
+      - run: git diff --exit-code
+
+  automerge:
+    name: Auto Merge Pull Request
+    runs-on: ubuntu-latest
+    needs: checks
+    steps:
+      - name: automerge
+        uses: pascalgn/automerge-action@v0.12.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_LABELS: dependabot
+          MERGE_METHOD: rebase


### PR DESCRIPTION
With the change from https://github.com/srcery-colors/srcery-terminal/pull/61, we need to change to some sort of auto merging ourselves.  This tries to solve that by using GitHub Actions.

Why this change?  Instead of manually merge dependencies updates, could this be automated with some actions.  The way I tried solving this is that I check for changes with `git diff --exit-code` and if the files are not changed with any deps update, all is safe I assume.  This exit status propagates to the auto-merging action and instructs it can auto-merge.

Thoughts?

---
It's rough now, and I only did submit this PR for testing the GitLab Actions (if it triggers that is. 😝 )