### PR TITLE
Alacritty hex prefix

### DIFF
--- a/alacritty/srcery_alacritty.yml
+++ b/alacritty/srcery_alacritty.yml
@@ -2,27 +2,27 @@
 colors:
   # Default colors
   primary:
-    background: '0x1c1b19'
-    foreground: '0xfce8c3'
+    background: '#1c1b19'
+    foreground: '#fce8c3'
 
   # Normal colors
   normal:
-    black:   '0x1c1b19'
-    red:     '0xef2f27'
-    green:   '0x519f50'
-    yellow:  '0xfbb829'
-    blue:    '0x2c78bf'
-    magenta: '0xe02c6d'
-    cyan:    '0x0aaeb3'
-    white:   '0xd0bfa1'
+    black:   '#1c1b19'
+    red:     '#ef2f27'
+    green:   '#519f50'
+    yellow:  '#fbb829'
+    blue:    '#2c78bf'
+    magenta: '#e02c6d'
+    cyan:    '#0aaeb3'
+    white:   '#d0bfa1'
 
   # Bright colors
   bright:
-    black:   '0x918175'
-    red:     '0xf75341'
-    green:   '0x98bc37'
-    yellow:  '0xfed06e'
-    blue:    '0x68a8e4'
-    magenta: '0xff5c8f'
-    cyan:    '0x53fde9'
-    white:   '0xfce8c3'
+    black:   '#918175'
+    red:     '#f75341'
+    green:   '#98bc37'
+    yellow:  '#fed06e'
+    blue:    '#68a8e4'
+    magenta: '#ff5c8f'
+    cyan:    '#53fde9'
+    white:   '#fce8c3'

--- a/bin/builder
+++ b/bin/builder
@@ -57,7 +57,7 @@ const terminalappColor = _.partialRight(_.mapValues, function(color) {
 const config = {
   alacritty: {
     template: "./templates/alacritty.dot",
-    function: toHexSlice
+    function: toHex
   },
   blink: {
     template: "./templates/blink.dot",

--- a/templates/alacritty.dot
+++ b/templates/alacritty.dot
@@ -2,27 +2,27 @@
 colors:
   # Default colors
   primary:
-    background: '0x{{=c.background}}'
-    foreground: '0x{{=c.foreground}}'
+    background: '{{=c.background}}'
+    foreground: '{{=c.foreground}}'
 
   # Normal colors
   normal:
-    black:   '0x{{=c[0]}}'
-    red:     '0x{{=c[1]}}'
-    green:   '0x{{=c[2]}}'
-    yellow:  '0x{{=c[3]}}'
-    blue:    '0x{{=c[4]}}'
-    magenta: '0x{{=c[5]}}'
-    cyan:    '0x{{=c[6]}}'
-    white:   '0x{{=c[7]}}'
+    black:   '{{=c[0]}}'
+    red:     '{{=c[1]}}'
+    green:   '{{=c[2]}}'
+    yellow:  '{{=c[3]}}'
+    blue:    '{{=c[4]}}'
+    magenta: '{{=c[5]}}'
+    cyan:    '{{=c[6]}}'
+    white:   '{{=c[7]}}'
 
   # Bright colors
   bright:
-    black:   '0x{{=c[8]}}'
-    red:     '0x{{=c[9]}}'
-    green:   '0x{{=c[10]}}'
-    yellow:  '0x{{=c[11]}}'
-    blue:    '0x{{=c[12]}}'
-    magenta: '0x{{=c[13]}}'
-    cyan:    '0x{{=c[14]}}'
-    white:   '0x{{=c[15]}}'
+    black:   '{{=c[8]}}'
+    red:     '{{=c[9]}}'
+    green:   '{{=c[10]}}'
+    yellow:  '{{=c[11]}}'
+    blue:    '{{=c[12]}}'
+    magenta: '{{=c[13]}}'
+    cyan:    '{{=c[14]}}'
+    white:   '{{=c[15]}}'


### PR DESCRIPTION
For alacritty, prefix hex colors with `#`, not `0x`.

This is consistent with the example config.
https://github.com/alacritty/alacritty/blob/master/alacritty.yml