### PR TITLE
Cursor palette property

### DIFF
--- a/bin/builder
+++ b/bin/builder
@@ -85,7 +85,7 @@ const config = {
   },
   kitty: {
     template: "./templates/kitty.dot",
-    function: toHexUpper
+    function: toHex
   },
   konsole: {
     template: "./templates/konsole.dot",

--- a/kitty/srcery_kitty.conf
+++ b/kitty/srcery_kitty.conf
@@ -3,42 +3,42 @@
 
 ## Special Colors
 
-foreground           #FCE8C3
-background           #1C1B19
-cursor               #FBB829
-selection_foreground #1C1B19
-selection_background #FCE8C3
+foreground           #fce8c3
+background           #1c1b19
+cursor               #fbb829
+selection_foreground #1c1b19
+selection_background #fce8c3
 
 ## Main Colors
 
 # Black
-color0               #1C1B19
+color0               #1c1b19
 color8               #918175
 
 # Red
-color1               #EF2F27
-color9               #F75341
+color1               #ef2f27
+color9               #f75341
 
 # Green
-color2               #519F50
-color10              #98BC37
+color2               #519f50
+color10              #98bc37
 
 # Yellow
-color3               #FBB829
-color11              #FED06E
+color3               #fbb829
+color11              #fed06e
 
 # Blue
-color4               #2C78BF
-color12              #68A8E4
+color4               #2c78bf
+color12              #68a8e4
 
 # Magenta
-color5               #E02C6D
-color13              #FF5C8F
+color5               #e02c6d
+color13              #ff5c8f
 
 # Cyan
-color6               #0AAEB3
-color14              #53FDE9
+color6               #0aaeb3
+color14              #53fde9
 
 # White
-color7               #D0BFA1
-color15              #FCE8C3
+color7               #d0bfa1
+color15              #fce8c3

--- a/palette.json
+++ b/palette.json
@@ -16,5 +16,6 @@
   "14": "#53fde9",
   "15": "#fce8c3",
   "foreground": "#fce8c3",
-  "background": "#1c1b19"
+  "background": "#1c1b19",
+  "cursor": "#fbb829"
 }

--- a/templates/blink.dot
+++ b/templates/blink.dot
@@ -22,4 +22,4 @@ t.prefs_.set("color-palette-overrides", [
 
 t.prefs_.set("foreground-color", "{{=c.foreground}}");
 t.prefs_.set("background-color", "{{=c.background}}");
-t.prefs_.set("cursor-color",     "{{=c[3]}}");
+t.prefs_.set("cursor-color",     "{{=c.cursor}}");

--- a/templates/chrome-secure-shell.dot
+++ b/templates/chrome-secure-shell.dot
@@ -1,4 +1,4 @@
 "background-color": "{{=c.background}}",
 "foreground-color": "{{=c.foreground}}",
-"cursor-color":     "{{=c[3]}}",
+"cursor-color":     "{{=c.cursor}}",
 "color-palette-overrides": ["{{=c[0]}}","{{=c[1]}}","{{=c[2]}}","{{=c[3]}}","{{=c[4]}}","{{=c[5]}}","{{=c[6]}}","{{=c[7]}}","{{=c[8]}}","{{=c[9]}}","{{=c[10]}}","{{=c[11]}}","{{=c[12]}}","{{=c[13]}}","{{=c[14]}}","{{=c[15]}}"]

--- a/templates/iterm.dot
+++ b/templates/iterm.dot
@@ -205,11 +205,11 @@
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>{{=c[3][2]}}</real>
+		<real>{{=c.cursor[2]}}</real>
 		<key>Green Component</key>
-		<real>{{=c[3][1]}}</real>
+		<real>{{=c.cursor[1]}}</real>
 		<key>Red Component</key>
-		<real>{{=c[3][0]}}</real>
+		<real>{{=c.cursor[0]}}</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>

--- a/templates/kitty.dot
+++ b/templates/kitty.dot
@@ -5,7 +5,7 @@
 
 foreground           {{=c.foreground}}
 background           {{=c.background}}
-cursor               {{=c[3]}}
+cursor               {{=c.cursor}}
 selection_foreground {{=c.background}}
 selection_background {{=c.foreground}}
 

--- a/templates/mintty.dot
+++ b/templates/mintty.dot
@@ -1,6 +1,6 @@
 BackgroundColour={{=c.background}}
 ForegroundColour={{=c.foreground}}
-CursorColour={{=c[3]}}
+CursorColour={{=c.cursor}}
 Black={{=c[0]}}
 BoldBlack={{=c[8]}}
 Red={{=c[1]}}

--- a/templates/pantheon.dot
+++ b/templates/pantheon.dot
@@ -2,7 +2,7 @@
 dconf load /org/pantheon/terminal/settings/ <<COLORS
 [/]
 name='srcery'
-cursor-color='{{=c[3]}}'
+cursor-color='{{=c.cursor}}'
 foreground='{{=c.foreground}}'
 background='{{=c.background}}'
 palette='{{=c[0]}}:{{=c[1]}}:{{=c[2]}}:{{=c[3]}}:{{=c[4]}}:{{=c[5]}}:{{=c[6]}}:{{=c[7]}}:{{=c[8]}}:{{=c[9]}}:{{=c[10]}}:{{=c[11]}}:{{=c[12]}}:{{=c[13]}}:{{=c[14]}}:{{=c[15]}}'

--- a/templates/terminal-app.dot
+++ b/templates/terminal-app.dot
@@ -72,7 +72,7 @@
 	</data>
 	<key>CursorColor</key>
 	<data>
-	{{=c[3]}}
+	{{=c.cursor}}
 	</data>
 	<key>SelectionColor</key>
 	<data>

--- a/templates/terminator.dot
+++ b/templates/terminator.dot
@@ -9,7 +9,7 @@
     palette = "{{=c[0]}}:{{=c[1]}}:{{=c[2]}}:{{=c[3]}}:{{=c[4]}}:{{=c[5]}}:{{=c[6]}}:{{=c[7]}}:{{=c[8]}}:{{=c[9]}}:{{=c[10]}}:{{=c[11]}}:{{=c[12]}}:{{=c[13]}}:{{=c[14]}}:{{=c[15]}}"
     foreground_color = "{{=c.foreground}}"
     background_color = "{{=c.background}}"
-    cursor_color = "{{=c[3]}}"
+    cursor_color = "{{=c.cursor}}"
 
 [layouts]
   [[default]]

--- a/templates/termite.dot
+++ b/templates/termite.dot
@@ -3,9 +3,9 @@
 # special
 foreground        = {{=c.foreground}}
 foreground_bold   = {{=c.foreground}}
-cursor            = {{=c[3]}}
-cursor_foreground = {{=c.background}}
 background        = {{=c.background}}
+cursor            = {{=c.cursor}}
+cursor_foreground = {{=c.background}}
 
 # black
 color0  = {{=c[0]}}

--- a/templates/tilix.dot
+++ b/templates/tilix.dot
@@ -3,7 +3,7 @@
   "badge-color": "{{=c[4]}}",
   "bold-color": "#FFFFFF",
   "comment": "Color scheme with clearly defined contrasting colors and a slightly earthy tone.",
-  "cursor-background-color": "{{=c[3]}}",
+  "cursor-background-color": "{{=c.cursor}}",
   "cursor-foreground-color": "{{=c.background}}",
   "foreground-color": "{{=c.foreground}}",
   "highlight-background-color": "#000000",

--- a/templates/windows_terminal.dot
+++ b/templates/windows_terminal.dot
@@ -25,7 +25,7 @@
       "brightWhite": "{{=c[15]}}",
       "foreground": "{{=c.foreground}}",
       "background": "{{=c.background}}",
-      "cursorColor": "{{=c[3]}}",
+      "cursorColor": "{{=c.cursor}}",
       "selectionBackground": "{{=c[15]}}"
     }
   ]

--- a/templates/xfce.dot
+++ b/templates/xfce.dot
@@ -1,6 +1,6 @@
 [Scheme]
 Name=srcery
-ColorCursor={{=c[3]}}
+ColorCursor={{=c.cursor}}
 ColorForeground={{=c.foreground}}
 ColorBackground={{=c.background}}
 ColorPalette={{=c[0]}};{{=c[1]}};{{=c[2]}};{{=c[3]}};{{=c[4]}};{{=c[5]}};{{=c[6]}};{{=c[7]}};{{=c[8]}};{{=c[9]}};{{=c[10]}};{{=c[11]}};{{=c[12]}};{{=c[13]}};{{=c[14]}};{{=c[15]}}

--- a/templates/xresources.dot
+++ b/templates/xresources.dot
@@ -1,7 +1,7 @@
 ! special
 *.foreground:   {{=c.foreground}}
 *.background:   {{=c.background}}
-*.cursorColor:  {{=c[3]}}
+*.cursorColor:  {{=c.cursor}}
 
 ! black
 *.color0:       {{=c[0]}}

--- a/termite/srcery_termite.ini
+++ b/termite/srcery_termite.ini
@@ -3,9 +3,9 @@
 # special
 foreground        = #fce8c3
 foreground_bold   = #fce8c3
+background        = #1c1b19
 cursor            = #fbb829
 cursor_foreground = #1c1b19
-background        = #1c1b19
 
 # black
 color0  = #1c1b19


### PR DESCRIPTION
This pull request adds a property named "cursor" (equal to color 3 - yellow) to the palette.json file.

The templates have been updated to use this property.
If the cursor color changes in the future, it only needs to be changed in palette.json instead of all the templates.