### PR TITLE
Sync with upstream st

### DIFF
--- a/st/srcery_st.h
+++ b/st/srcery_st.h
@@ -34,5 +34,5 @@ static const char *colorname[] = {
  */
 unsigned int defaultfg = 256;
 unsigned int defaultbg = 257;
-static unsigned int defaultcs = 258;
+unsigned int defaultcs = 258;
 static unsigned int defaultrcs = 257;

--- a/templates/st.dot
+++ b/templates/st.dot
@@ -34,5 +34,5 @@ static const char *colorname[] = {
  */
 unsigned int defaultfg = 256;
 unsigned int defaultbg = 257;
-static unsigned int defaultcs = 258;
+unsigned int defaultcs = 258;
 static unsigned int defaultrcs = 257;


### PR DESCRIPTION
Suckless removed the "static" keyword from variable defaultcs.
https://git.suckless.org/st/commit/8e310303903792c010d03c046ba75f8b18f7d3a7.html