### PR TITLE
fix Xresources syntax to work with other applications

### DIFF
--- a/xresources/srcery.xresources
+++ b/xresources/srcery.xresources
@@ -1,36 +1,36 @@
 ! special
-*.foreground:   #fce8c3
-*.background:   #1c1b19
-*.cursorColor:  #fbb829
+*foreground:   #fce8c3
+*background:   #1c1b19
+*cursorColor:  #fbb829
 
 ! black
-*.color0:       #1c1b19
-*.color8:       #918175
+*color0:       #1c1b19
+*color8:       #918175
 
 ! red
-*.color1:       #ef2f27
-*.color9:       #f75341
+*color1:       #ef2f27
+*color9:       #f75341
 
 ! green
-*.color2:       #519f50
-*.color10:      #98bc37
+*color2:       #519f50
+*color10:      #98bc37
 
 ! yellow
-*.color3:       #fbb829
-*.color11:      #fed06e
+*color3:       #fbb829
+*color11:      #fed06e
 
 ! blue
-*.color4:       #2c78bf
-*.color12:      #68a8e4
+*color4:       #2c78bf
+*color12:      #68a8e4
 
 ! magenta
-*.color5:       #e02c6d
-*.color13:      #ff5c8f
+*color5:       #e02c6d
+*color13:      #ff5c8f
 
 ! cyan
-*.color6:       #0aaeb3
-*.color14:      #2be4d0
+*color6:       #0aaeb3
+*color14:      #2be4d0
 
 ! white
-*.color7:       #baa67f
-*.color15:      #fce8c3
+*color7:       #baa67f
+*color15:      #fce8c3


### PR DESCRIPTION
In i3, I was trying to use the `i3wm.colorX` pattern to access those
resources, and that doesn't work because `*` and `.` are
two *different* bindings. In other words, `*` is not a wildcard like
you would expect in another language.

In the X(7) manual page[1], it says:

> When an application looks for the value of a resource, it specifies
> a complete path in the hierarchy, with both class and instance
> names. However, resource values are usually given with only
> partially specified names and classes, using pattern matching
> constructs. An asterisk (*) is a loose binding and is used to
> represent any number of intervening components, including none. A
> period (.) is a tight binding and is used to separate immediately
> adjacent components. A question mark (?) is used to match any single
> component name or class. A database entry cannot end in a loose
> binding; the final component (which cannot be "?") must be
> specified. The lookup algorithm searches the resource database for
> the entry that most closely matches (is most specific for) the full
> name and class being queried. When more than one database entry
> matches the full name and class, precedence rules are used to select
> just one.

[1]: https://manpages.debian.org/bullseye/xorg-docs-core/X.7.en.html#RESOURCES

Now that I re-read this (a third time), it seems that `*.` *should*
work because `*` represents "any number of components, including
none", but the fact is it actually doesn't. It's possible this is a
bug in `xcb-util-xrm`, but I think it's safer to fix this by using the
simpler approach instead.

I have confirmed the modified version works in *both* i3 and xterm,
which is what I was looking for.

See https://github.com/i3/i3/discussions/5051 for a further discussion.