### PR TITLE
fix: follow kitty template.conf

### DIFF
--- a/kitty/srcery_kitty.conf
+++ b/kitty/srcery_kitty.conf
@@ -1,44 +1,56 @@
-### srcery_kitty.conf
-### https://github.com/srcery-colors/srcery-terminal/
+# vim:ft=kitty
 
-## Special Colors
+## name: srcery
+## author: Daniel Berg
+## license: MIT
+## upstream: https://github.com/srcery-colors/srcery-terminal/
+## blurb: Srcery is a color scheme with clearly defined contrasting colors and
+## a slightly earthy tone.
 
-foreground           #fce8c3
-background           #1c1b19
-cursor               #fbb829
-selection_foreground #1c1b19
-selection_background #fce8c3
+#: The basic colors
 
-## Main Colors
+foreground                      #fce8c3
+background                      #1c1b19
+selection_foreground            #1c1b19
+selection_background            #fce8c3
 
-# Black
-color0               #1c1b19
-color8               #918175
 
-# Red
-color1               #ef2f27
-color9               #f75341
+#: Cursor colors
 
-# Green
-color2               #519f50
-color10              #98bc37
+cursor                          #fbb829
+cursor_text_color               background
 
-# Yellow
-color3               #fbb829
-color11              #fed06e
 
-# Blue
-color4               #2c78bf
-color12              #68a8e4
+#: The basic 16 colors
 
-# Magenta
-color5               #e02c6d
-color13              #ff5c8f
+#: black
+color0 #1c1b19
+color8 #918175
 
-# Cyan
-color6               #0aaeb3
-color14              #2be4d0
+#: red
+color1 #ef2f27
+color9 #f75341
 
-# White
-color7               #baa67f
-color15              #fce8c3
+#: green
+color2  #519f50
+color10 #98bc37
+
+#: yellow
+color3  #fbb829
+color11 #fed06e
+
+#: blue
+color4  #2c78bf
+color12 #68a8e4
+
+#: magenta
+color5  #e02c6d
+color13 #ff5c8f
+
+#: cyan
+color6  #0aaeb3
+color14 #2be4d0
+
+#: white
+color7  #baa67f
+color15 #fce8c3

--- a/templates/kitty.hbs
+++ b/templates/kitty.hbs
@@ -1,44 +1,56 @@
-### srcery_kitty.conf
-### https://github.com/srcery-colors/srcery-terminal/
+# vim:ft=kitty
 
-## Special Colors
+## name: srcery
+## author: Daniel Berg
+## license: MIT
+## upstream: https://github.com/srcery-colors/srcery-terminal/
+## blurb: Srcery is a color scheme with clearly defined contrasting colors and
+## a slightly earthy tone.
 
-foreground           {{lower primary.bright_white.hex }}
-background           {{lower primary.black.hex }}
-cursor               {{lower primary.yellow.hex }}
-selection_foreground {{lower primary.black.hex }}
-selection_background {{lower primary.bright_white.hex }}
+#: The basic colors
 
-## Main Colors
+foreground                      {{lower primary.bright_white.hex }}
+background                      {{lower primary.black.hex }}
+selection_foreground            {{lower primary.black.hex }}
+selection_background            {{lower primary.bright_white.hex }}
 
-# Black
-color0               {{lower primary.black.hex }}
-color8               {{lower primary.bright_black.hex }}
 
-# Red
-color1               {{lower primary.red.hex }}
-color9               {{lower primary.bright_red.hex }}
+#: Cursor colors
 
-# Green
-color2               {{lower primary.green.hex }}
-color10              {{lower primary.bright_green.hex }}
+cursor                          {{lower primary.yellow.hex }}
+cursor_text_color               background
 
-# Yellow
-color3               {{lower primary.yellow.hex }}
-color11              {{lower primary.bright_yellow.hex }}
 
-# Blue
-color4               {{lower primary.blue.hex }}
-color12              {{lower primary.bright_blue.hex }}
+#: The basic 16 colors
 
-# Magenta
-color5               {{lower primary.magenta.hex }}
-color13              {{lower primary.bright_magenta.hex }}
+#: black
+color0 {{lower primary.black.hex }}
+color8 {{lower primary.bright_black.hex }}
 
-# Cyan
-color6               {{lower primary.cyan.hex }}
-color14              {{lower primary.bright_cyan.hex }}
+#: red
+color1 {{lower primary.red.hex }}
+color9 {{lower primary.bright_red.hex }}
 
-# White
-color7               {{lower primary.white.hex }}
-color15              {{lower primary.bright_white.hex }}
+#: green
+color2  {{lower primary.green.hex }}
+color10 {{lower primary.bright_green.hex }}
+
+#: yellow
+color3  {{lower primary.yellow.hex }}
+color11 {{lower primary.bright_yellow.hex }}
+
+#: blue
+color4  {{lower primary.blue.hex }}
+color12 {{lower primary.bright_blue.hex }}
+
+#: magenta
+color5  {{lower primary.magenta.hex }}
+color13 {{lower primary.bright_magenta.hex }}
+
+#: cyan
+color6  {{lower primary.cyan.hex }}
+color14 {{lower primary.bright_cyan.hex }}
+
+#: white
+color7  {{lower primary.white.hex }}
+color15 {{lower primary.bright_white.hex }}


### PR DESCRIPTION
Update the kitty template to have the same format used by the kitty-themes repo.

The template is here:
https://github.com/kovidgoyal/kitty-themes/blob/master/template.conf