### PR TITLE
Add ghostty terminal theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ FILES = alacritty/srcery_alacritty.toml \
 				chrome_secure_shell/srcery_chrome_secure_shell.prefs.js \
 				foot/foot.ini \
 				genode-terminal/srcery_genode-terminal.config \
+				ghostty/srcery \
 				gnome-terminal/srcery_gnome-terminal.sh \
 				guake/srcery_guake.sh \
 				iterm/srcery_iterm.itermcolors \
@@ -51,6 +52,9 @@ foot/foot.ini: templates/foot.hbs $(PALETTE)
 
 genode-terminal/srcery_genode-terminal.config: templates/genode.hbs $(PALETTE)
 	bin/builder -o genode > $@
+
+ghostty/srcery: templates/ghostty.hbs $(PALETTE)
+	bin/builder -o ghostty > $@
 
 gnome-terminal/srcery_gnome-terminal.sh: templates/gnome.hbs $(PALETTE)
 	bin/builder -o gnome > $@

--- a/bin/builder
+++ b/bin/builder
@@ -51,6 +51,7 @@ const templates = {
   chromeshell:     "templates/chrome-secure-shell.hbs",
   foot:		   "templates/foot.hbs",
   genode:          "templates/genode.hbs",
+  ghostty:         "templates/ghostty.hbs",
   gnome:           "templates/gnome.hbs",
   guake:           "templates/guake.hbs",
   iterm:           "templates/iterm.hbs",

--- a/ghostty/srcery
+++ b/ghostty/srcery
@@ -1,0 +1,23 @@
+# https://github.com/srcery-colors/srcery-terminal/
+cursor-color = #fbb829
+foreground = #fce8c3
+background = #1c1b19
+selection-foreground = #1c1b19
+selection-background = #fce8c3
+
+pallete = 0=#1c1b19
+pallete = 1=#ef2f27
+pallete = 2=#519f50
+pallete = 3=#fbb829
+pallete = 4=#2c78bf
+pallete = 5=#e02c6d
+pallete = 6=#0aaeb3
+pallete = 7=#baa67f
+pallete = 8=#918175
+pallete = 9=#f75341
+pallete = 10=#98bc37
+pallete = 11=#fed06e
+pallete = 12=#68a8e4
+pallete = 13=#ff5c8f
+pallete = 14=#2be4d0
+pallete = 15=#fce8c3

--- a/templates/ghostty.hbs
+++ b/templates/ghostty.hbs
@@ -1,0 +1,23 @@
+# https://github.com/srcery-colors/srcery-terminal/
+cursor-color = {{lower primary.yellow.hex}}
+foreground = {{lower primary.bright_white.hex}}
+background = {{lower primary.black.hex}}
+selection-foreground = {{lower primary.black.hex}}
+selection-background = {{lower primary.bright_white.hex}}
+
+pallete = 0={{lower primary.black.hex}}
+pallete = 1={{lower primary.red.hex}}
+pallete = 2={{lower primary.green.hex}}
+pallete = 3={{lower primary.yellow.hex}}
+pallete = 4={{lower primary.blue.hex}}
+pallete = 5={{lower primary.magenta.hex}}
+pallete = 6={{lower primary.cyan.hex}}
+pallete = 7={{lower primary.white.hex}}
+pallete = 8={{lower primary.bright_black.hex}}
+pallete = 9={{lower primary.bright_red.hex}}
+pallete = 10={{lower primary.bright_green.hex}}
+pallete = 11={{lower primary.bright_yellow.hex}}
+pallete = 12={{lower primary.bright_blue.hex}}
+pallete = 13={{lower primary.bright_magenta.hex}}
+pallete = 14={{lower primary.bright_cyan.hex}}
+pallete = 15={{lower primary.bright_white.hex}}


### PR DESCRIPTION
This pull request adds template, builder entry, make command and compiled config theme for [Ghostty](https://ghostty.org) terminal.

The exact colors are chosen similarly to the theme for kitty or termux terminals since config is really similar.